### PR TITLE
Fixing post generation

### DIFF
--- a/multipost.rb
+++ b/multipost.rb
@@ -72,7 +72,7 @@ module Jekyll
           :site => site,
           :collection => collection
         })
-
+        new_doc.read
         new_doc.data["layout"] = layout
         new_doc.data["permalink"] = PermalinkBuilder.get_adjusted_permalink(doc, layout)
 

--- a/multipost.rb
+++ b/multipost.rb
@@ -68,15 +68,15 @@ module Jekyll
 
     def create_layout_views(site, collection, doc)
       doc.data["layout"].map do |layout|
-        doc = Document.new(doc.path, {
+        new_doc = Document.new(doc.path, {
           :site => site,
           :collection => collection
         })
 
-        doc.data["layout"] = layout
-        doc.data["permalink"] = PermalinkBuilder.get_adjusted_permalink(doc, layout)
+        new_doc.data["layout"] = layout
+        new_doc.data["permalink"] = PermalinkBuilder.get_adjusted_permalink(doc, layout)
 
-        doc
+        new_doc
       end
     end
   end


### PR DESCRIPTION
I was playing around with your code this morning and found a few bugs. 
- You had a variable conflict by using the variable `doc` when copying `doc`
- The new documents didn't have any content in them. Apparently you need to call `doc.read` in Jekyll 3. Don't know why this step doesn't happen after the generators have run, as it did in Jekyll 2.

Feel free to use or throw away :)
